### PR TITLE
Add render form and render index methods as options in field configs

### DIFF
--- a/lib/kaffy/resource_form.ex
+++ b/lib/kaffy/resource_form.ex
@@ -393,11 +393,14 @@ defmodule Kaffy.ResourceForm do
   def kaffy_input(conn, changeset, form, field, options) do
     ft = Kaffy.ResourceSchema.field_type(changeset.data.__struct__, field)
 
-    case Kaffy.Utils.is_module(ft) && Keyword.has_key?(ft.__info__(:functions), :render_form) do
-      true ->
+    cond do
+      is_function(options.render_form) ->
+        options.render_form.(conn, changeset, form, field, options)
+
+      Kaffy.Utils.is_module(ft) && Keyword.has_key?(ft.__info__(:functions), :render_form) ->
         ft.render_form(conn, changeset, form, field, options)
 
-      false ->
+      true ->
         {error_msg, error_class} = get_field_error(changeset, field)
         help_text = form_help_text({field, options})
 

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -61,7 +61,8 @@ defmodule Kaffy.ResourceSchema do
       update: :editable,
       label: nil,
       type: nil,
-      choices: nil
+      choices: nil,
+      render_form: nil
     }
 
     Map.merge(default, options || %{})
@@ -173,6 +174,9 @@ defmodule Kaffy.ResourceSchema do
           |> Map.drop([:__meta__])
           |> Kaffy.Utils.json().encode!(escape: :html_safe, pretty: true)
         end
+
+      !is_nil(options) and Map.has_key?(options, :render_index) and is_function(options.render_index) ->
+        options.render_index.(schema, field, options)
 
       Kaffy.Utils.is_module(ft) && Keyword.has_key?(ft.__info__(:functions), :render_index) ->
         ft.render_index(conn, schema, field, options)

--- a/test/kaffy_test.exs
+++ b/test/kaffy_test.exs
@@ -2,7 +2,7 @@ defmodule KaffyTest do
   use ExUnit.Case
   doctest Kaffy
   alias KaffyTest.Schemas.{Person, Pet}
-  # alias KaffyTest.Admin.PersonAdmin
+  alias KaffyTest.Admin.PersonAdmin
 
   test "greets the world" do
     assert Kaffy.hello() == :world
@@ -78,6 +78,19 @@ defmodule KaffyTest do
     test "association_schema/2 must return the schema of the association" do
       assert Pet == ResourceSchema.association_schema(Person, :pets)
       assert Person == ResourceSchema.association_schema(Pet, :person)
+    end
+  end
+
+  describe "Kaffy.ResourceForm" do
+    alias Kaffy.ResourceAdmin
+    alias Kaffy.ResourceForm
+
+    test "kaffy_input/5 should return the custom form field when render_form is in options" do
+      for {field, options} <- ResourceAdmin.form_fields(%{admin: PersonAdmin, schema: Person}) do
+        assert [
+          {:safe, ~s(<div class="form-group">Custom Form Field Goes Here.</div>)}
+        ] == ResourceForm.kaffy_input(nil, Person.changeset(%Person{}, %{address: "101 Baker St"}), nil, field, options)
+      end
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,7 @@ ExUnit.start()
 
 defmodule KaffyTest.Schemas.Person do
   use Ecto.Schema
+  import Ecto.Changeset
 
   schema "people" do
     field(:name, :string)
@@ -11,6 +12,11 @@ defmodule KaffyTest.Schemas.Person do
     field(:address, :string)
     has_many(:pets, KaffyTest.Schemas.Pet)
   end
+
+  def changeset(person, params \\ %{}) do
+    person
+    |> cast(params, [:name, :age, :married, :birth_date, :address])
+  end
 end
 
 defmodule KaffyTest.Admin.PersonAdmin do
@@ -18,6 +24,18 @@ defmodule KaffyTest.Admin.PersonAdmin do
     [
       name: nil,
       married: %{value: fn p -> if p.married, do: "yes", else: "no" end}
+    ]
+  end
+
+  def form_fields(_schema) do
+    [
+      address: %{render_form: &render_form/5}
+    ]
+  end
+
+  def render_form(_conn, _changeset, _form, _field, _options) do
+    [
+      {:safe, ~s(<div class="form-group">Custom Form Field Goes Here.</div>)}
     ]
   end
 end


### PR DESCRIPTION
Issue #4 

This PR is sort've addressing the tight coupling with Ecto types. It seemed to me like Andy's biggest problem with that was that you needed to add the `render_form` and `render_index` methods to the Ecto type which he didn't have access to for dependencies like Money and Waffles, so this allows you to pass in anonymous functions as part of the options when calling `form_fields` or `index`, respectively. Below shows how you would call it just like any of the other options.

<img width="548" alt="Screen Shot 2021-11-17 at 4 31 16 PM" src="https://user-images.githubusercontent.com/25255820/142285669-ffa6da98-e370-42b7-96da-70bbb7db3f59.png">

