### PR TITLE
Allow users to create multiple dashboards

### DIFF
--- a/lib/kaffy/routes.ex
+++ b/lib/kaffy/routes.ex
@@ -32,6 +32,7 @@ defmodule Kaffy.Routes do
 
         get("/", HomeController, :index, as: :kaffy_home)
         get("/dashboard", HomeController, :dashboard, as: :kaffy_dashboard)
+        get("/custom-dashboard/:context", CustomDashboardController, :index, as: :kaffy_custom_dashboard)
         get("/tasks", TaskController, :index, as: :kaffy_task)
         get("/p/:slug", PageController, :index, as: :kaffy_page)
         get("/:context/:resource", ResourceController, :index, as: :kaffy_resource)

--- a/lib/kaffy/utils.ex
+++ b/lib/kaffy/utils.ex
@@ -129,6 +129,13 @@ defmodule Kaffy.Utils do
     end
   end
 
+  def full_dashboards(conn) do
+    case env(:dashboards) do
+      f when is_function(f) -> f.(conn)
+      _ -> []
+    end
+  end
+
   @doc """
   Returns a list of contexts as atoms.
 
@@ -140,6 +147,11 @@ defmodule Kaffy.Utils do
   @spec contexts(Plug.Conn.t()) :: [atom()]
   def contexts(conn) do
     full_resources(conn)
+    |> Enum.map(fn {context, _options} -> context end)
+  end
+
+  def dashboard_contexts(conn) do
+    full_dashboards(conn)
     |> Enum.map(fn {context, _options} -> context end)
   end
 
@@ -177,6 +189,15 @@ defmodule Kaffy.Utils do
   def context_name(conn, context) do
     default = Kaffy.ResourceAdmin.humanize_term(context)
     get_in(full_resources(conn), [context, :name]) || default
+  end
+
+  def dashboard_context_name(conn, context) when is_atom(context) do
+    default = Kaffy.ResourceAdmin.humanize_term(context)
+    get_in(full_dashboards(conn), [context, :name]) || default
+  end
+  def dashboard_context_name(conn, context) do
+    context = convert_to_atom(context)
+    dashboard_context_name(conn, context)
   end
 
   @doc """
@@ -217,6 +238,11 @@ defmodule Kaffy.Utils do
   def get_resource(conn, context, resource) do
     {context, resource} = convert_to_atoms(context, resource)
     get_in(full_resources(conn), [context, :resources, resource])
+  end
+
+  def get_dashboard(conn, context) do
+    context = convert_to_atom(context)
+    get_in(full_dashboards(conn), [context, :admin])
   end
 
   @doc """

--- a/lib/kaffy_web/controllers/custom_dashboard_controller.ex
+++ b/lib/kaffy_web/controllers/custom_dashboard_controller.ex
@@ -1,0 +1,19 @@
+defmodule KaffyWeb.CustomDashboardController do
+  @moduledoc false
+
+  use Phoenix.Controller, namespace: KaffyWeb
+
+  def index(conn, %{"context" => context}) do
+    my_dashboard = Kaffy.Utils.get_dashboard(conn, context)
+    widgets = case !is_nil(my_dashboard) && Kaffy.Utils.has_function?(my_dashboard, :widgets) do
+      true -> apply(my_dashboard, :widgets, [conn])
+      false -> []
+    end
+    name = Kaffy.Utils.dashboard_context_name(conn, context)
+
+    render(conn, "index.html",
+      dashboard_context: context,
+      widgets: widgets,
+      name: name)
+  end
+end

--- a/lib/kaffy_web/templates/custom_dashboard/index.html.eex
+++ b/lib/kaffy_web/templates/custom_dashboard/index.html.eex
@@ -1,0 +1,35 @@
+<div class="page-header">
+    <h3 class="page-title"><%= @name %></h3>
+</div>
+
+<%= if Enum.empty?(@widgets) do %>
+
+    <div class="row mt-3">
+        <div class="col-md-12 text-center">
+            <h4>You can add widgets to this page by defining <code>widgets/1</code> in your dashboard's admin module.</h4>
+        </div>
+    </div>
+
+<% else %>
+
+    <div class="row mt-1 row-cols-1 row-cols-md-2 row-cols-sm-1 row-cols-xs-1">
+        <%= for widget <- @widgets do %>
+            <%= if widget.type == "text" do %>
+                <%= render KaffyWeb.HomeView, "_text.html", widget: widget %>
+            <% end %>
+
+            <%= if widget.type == "chart" do %>
+                <%= render KaffyWeb.HomeView, "_chart.html", widget: widget %>
+            <% end %>
+
+            <%= if widget.type == "progress" do %>
+                <%= render KaffyWeb.HomeView, "_progress.html", widget: widget %>
+            <% end %>
+
+            <%= if widget.type == "tidbit" do %>
+                <%= render KaffyWeb.HomeView, "_tidbit.html", widget: widget %>
+            <% end %>
+        <% end %>
+    </div>
+
+<% end %>

--- a/lib/kaffy_web/templates/layout/app.html.eex
+++ b/lib/kaffy_web/templates/layout/app.html.eex
@@ -42,10 +42,19 @@
           <ul class="nav">
 
             <%= if Kaffy.Utils.show_dashboard?() do %>
-              <li class="nav-item<%= if @conn.assigns[:context] == nil do %> active<% end %>">
+              <li class="nav-item<%= if @conn.assigns[:context] == nil and @conn.assigns[:dashboard_context] == nil do %> active<% end %>">
                 <%= link to: Kaffy.Utils.router().kaffy_dashboard_path(@conn, :dashboard), class: "nav-link" do %>
                   <span class="menu-title">Dashboard</span>
                   <i class="fas fa-home menu-icon"></i>
+                <% end %>
+              </li>
+            <% end %>
+
+            <%= for dashboard <- Kaffy.Utils.dashboard_contexts(@conn) do %>
+              <li class="nav-item<%= if @conn.assigns[:dashboard_context] == to_string(dashboard) do %> active<% end %>">
+                <%= link to: Kaffy.Utils.router().kaffy_custom_dashboard_path(@conn, :index, dashboard), class: "nav-link" do %>
+                  <span class="menu-title"><%= Kaffy.Utils.dashboard_context_name(@conn, dashboard) %></span>
+                  <i class="fas fa-chart-line menu-icon"></i>
                 <% end %>
               </li>
             <% end %>

--- a/lib/kaffy_web/views/custom_dashboard_view.ex
+++ b/lib/kaffy_web/views/custom_dashboard_view.ex
@@ -1,0 +1,10 @@
+defmodule KaffyWeb.CustomDashboardView do
+  @moduledoc false
+
+  use Phoenix.View,
+    root: "lib/kaffy_web/templates",
+    namespace: KaffyWeb
+
+  # import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]
+  use Phoenix.HTML
+end


### PR DESCRIPTION
Issue #4 

This PR allows users to create multiple dashboards by passing them in through the kaffy config setting similar to `resources` or `ecto_repo`. 

### Screenshots

<img width="428" alt="Screen Shot 2021-11-19 at 11 03 16 AM" src="https://user-images.githubusercontent.com/25255820/142653671-d12fe1a6-4ee0-4006-b804-b70bd47d5a26.png">
<img width="427" alt="Screen Shot 2021-11-19 at 11 03 28 AM" src="https://user-images.githubusercontent.com/25255820/142653674-6b1b1510-ea8d-48d3-beb8-96b21fb784dc.png">

![Screen Shot 2021-11-19 at 11 03 38 AM](https://user-images.githubusercontent.com/25255820/142653795-b19c0064-0cf5-46e5-85d8-2a78f369a247.png)