### PR TITLE
Add conn to form_fields and index

### DIFF
--- a/lib/kaffy/resource_admin.ex
+++ b/lib/kaffy/resource_admin.ex
@@ -12,7 +12,7 @@ defmodule Kaffy.ResourceAdmin do
   """
 
   @doc """
-  `index/1` takes the schema module and should return a keyword list of fields and
+  `index/2` takes the schema module and should return a keyword list of fields and
   their options.
 
   Supported options are `:name` and `:value`.
@@ -21,7 +21,7 @@ defmodule Kaffy.ResourceAdmin do
 
   If a function is provided, the current entry is passed to it.
 
-  If index/1 is not defined, Kaffy will return all the fields of the schema and their default values.
+  If index/2 is not defined, Kaffy will return all the fields of the schema and their default values.
 
   Example:
 
@@ -37,13 +37,13 @@ defmodule Kaffy.ResourceAdmin do
   end
   ```
   """
-  def index(resource) do
+  def index(resource, conn) do
     schema = resource[:schema]
-    Utils.get_assigned_value_or_default(resource, :index, ResourceSchema.index_fields(schema))
+    Utils.get_assigned_value_or_default(resource, :index, ResourceSchema.index_fields(schema), [conn])
   end
 
   @doc """
-  form_fields/1 takes a schema and returns a keyword list of fields and their options for the new/edit form.
+  form_fields/2 takes a schema and returns a keyword list of fields and their options for the new/edit form.
 
   Supported options are:
 
@@ -58,13 +58,13 @@ defmodule Kaffy.ResourceAdmin do
 
   If you want to remove a field from being rendered, just remove it from the list.
 
-  If form_fields/1 is not defined, Kaffy will return all the fields with
+  If form_fields/2 is not defined, Kaffy will return all the fields with
   their default types based on the schema.
 
   Example:
 
   ```elixir
-  def form_fields(_schema) do
+  def form_fields(_schema, _conn) do
     [
       title: %{label: "Subject"},
       slug: nil,
@@ -76,13 +76,14 @@ defmodule Kaffy.ResourceAdmin do
   end
   ```
   """
-  def form_fields(resource) do
+  def form_fields(resource, conn) do
     schema = resource[:schema]
 
     Utils.get_assigned_value_or_default(
       resource,
       :form_fields,
-      ResourceSchema.form_fields(schema)
+      ResourceSchema.form_fields(schema),
+      [conn]
     )
     |> set_default_field_options(schema)
   end

--- a/lib/kaffy/resource_schema.ex
+++ b/lib/kaffy/resource_schema.ex
@@ -123,8 +123,8 @@ defmodule Kaffy.ResourceSchema do
     end
   end
 
-  def has_field_filters?(resource) do
-    admin_fields = Kaffy.ResourceAdmin.index(resource)
+  def has_field_filters?(resource, conn) do
+    admin_fields = Kaffy.ResourceAdmin.index(resource, conn)
 
     fields_with_filters =
       Enum.map(admin_fields, fn f -> kaffy_field_filters(resource[:schema], f) end)

--- a/lib/kaffy_web/controllers/resource_controller.ex
+++ b/lib/kaffy_web/controllers/resource_controller.ex
@@ -22,7 +22,7 @@ defmodule KaffyWeb.ResourceController do
         unauthorized_access(conn)
 
       true ->
-        fields = Kaffy.ResourceAdmin.index(my_resource)
+        fields = Kaffy.ResourceAdmin.index(my_resource, conn)
         {filtered_count, entries} = Kaffy.ResourceQuery.list_resource(conn, my_resource, params)
         items_per_page = Map.get(params, "limit", "100") |> String.to_integer()
         page = Map.get(params, "page", "1") |> String.to_integer()
@@ -59,7 +59,7 @@ defmodule KaffyWeb.ResourceController do
         unauthorized_access(conn)
 
       true ->
-        fields = Kaffy.ResourceAdmin.index(my_resource)
+        fields = Kaffy.ResourceAdmin.index(my_resource, conn)
         {filtered_count, entries} = Kaffy.ResourceQuery.list_resource(conn, my_resource, params)
         items_per_page = Map.get(params, "limit", "100") |> String.to_integer()
         page = Map.get(params, "page", "1") |> String.to_integer()

--- a/lib/kaffy_web/templates/resource/_list_table.html.eex
+++ b/lib/kaffy_web/templates/resource/_list_table.html.eex
@@ -5,7 +5,7 @@
         <% end %>
     </tr>
 
-    <%= if Kaffy.ResourceSchema.has_field_filters?(@my_resource) do %>
+    <%= if Kaffy.ResourceSchema.has_field_filters?(@my_resource, @conn) do %>
         <tr>
             <%= for {field, index} <- Enum.with_index(@fields) do %>
                 <% {field, filters} = Kaffy.ResourceSchema.kaffy_field_filters(@my_resource[:schema], field) %>

--- a/lib/kaffy_web/templates/resource/_table.html.eex
+++ b/lib/kaffy_web/templates/resource/_table.html.eex
@@ -1,6 +1,6 @@
 <table class="table table-striped">
     <thead>
-        <%= render KaffyWeb.ResourceView, "_table_header.html", my_resource: @my_resource, fields: @fields, params: @params %>
+        <%= render KaffyWeb.ResourceView, "_table_header.html", my_resource: @my_resource, fields: @fields, params: @params, conn: @conn %>
     </thead>
 
     <tbody>

--- a/lib/kaffy_web/templates/resource/_table_header.html.eex
+++ b/lib/kaffy_web/templates/resource/_table_header.html.eex
@@ -19,7 +19,7 @@
     <% end %>
 </tr>
 
-<%= if Kaffy.ResourceSchema.has_field_filters?(@my_resource) do %>
+<%= if Kaffy.ResourceSchema.has_field_filters?(@my_resource, @conn) do %>
     <tr>
         <th class="bg-light"></th>
         <%= for {field, index} <- Enum.with_index(@fields) do %>

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -77,7 +77,7 @@
 </div>
 
 <form id="kaffy-filters-form" method="get" style="display:none;">
-  <%= if Kaffy.ResourceSchema.has_field_filters?(@my_resource) do %>
+  <%= if Kaffy.ResourceSchema.has_field_filters?(@my_resource, @conn) do %>
     <%= for field <- @fields do %>
         <% {field, filters} = Kaffy.ResourceSchema.kaffy_field_filters(@my_resource[:schema], field) %>
         <%= if filters do %>

--- a/lib/kaffy_web/templates/resource/new.html.eex
+++ b/lib/kaffy_web/templates/resource/new.html.eex
@@ -15,7 +15,7 @@
         </div>
         <div class="card-body">
             <%= f = form_for(@changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :create, @context, @resource), method: :post, multipart: true) %>
-                <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
+                <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource, @conn) do %>
                     <%= if options.create != :hidden do %>
                         <%= Kaffy.ResourceForm.kaffy_input @conn, @changeset, f, field, options %>
                     <% end %>

--- a/lib/kaffy_web/templates/resource/pick_resource.html.eex
+++ b/lib/kaffy_web/templates/resource/pick_resource.html.eex
@@ -26,7 +26,7 @@
 </div>
 
 <form id="kaffy-filters-form" method="get" style="display:none;">
-  <%= if Kaffy.ResourceSchema.has_field_filters?(@my_resource) do %>
+  <%= if Kaffy.ResourceSchema.has_field_filters?(@my_resource, @conn) do %>
     <%= for field <- @fields do %>
         <% {field, filters} = Kaffy.ResourceSchema.kaffy_field_filters(@my_resource[:schema], field) %>
         <%= if filters do %>

--- a/lib/kaffy_web/templates/resource/show.html.eex
+++ b/lib/kaffy_web/templates/resource/show.html.eex
@@ -33,7 +33,7 @@
         </div>
         <div class="card-body">
             <%= f = form_for(@changeset, Kaffy.Utils.router().kaffy_resource_path(@conn, :update, @context, @resource, @changeset.data.id), method: :put, multipart: true) %>
-                <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource) do %>
+                <%= for {field, options} <- Kaffy.ResourceAdmin.form_fields(@my_resource, @conn) do %>
                     <%= if options.update != :hidden do %>
                         <%= Kaffy.ResourceForm.kaffy_input @conn, @changeset, f, field, options %>
                     <% end %>


### PR DESCRIPTION
Issue #4 

On the authorization of fields, you can authorize fields in both the `index` and `form_fields` methods to determine whether they should appear or not. I re-read that initial issue and realized that Andy's problem with this wasn't that they couldn't be hidden, it was just that he needed `conn` to determine whether or not certain fields should be hidden, so I just added it to both of the methods.