### PR TITLE
Allow list action input to be a select

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ The `:values_fn` is passed the entity you are editing and the conn (in that orde
 A `belongs_to` association should be referenced by the field name, *not* the association name. For example, a schema with the following association:
 
 ```
-schema "my_model" do 
+schema "my_model" do
   ...
   belongs_to :owner, App.Owners.Owner
   ...
@@ -839,7 +839,10 @@ The values are maps providing a human-friendly `:name` and an `:action` that is 
 
 The `change_price` action is a multi-step action.
 The defined `:inputs` option will display a popup with a form that contains defined in this option.
-`:inputs` should be a list of maps. Each input must have a `:name`, a `:title`, and a `:default` value.
+`:inputs` should be a list of maps. Each input must have a `:name` and a `:title`.
+An optional key in the input map is `:use_select`, which defaults to `false`.
+If `true`, the input becomes a `select` instead by using a passed in list called `:options`, which is a list of lists formatted like so `[[display, value], [display, value]]`.
+If `false`, a `:default` value is required for the text input.
 After submitting the popup form, the extra values, along with the selected resources, are passed to the `:action` function.
 In the example above, `change_price/2` will receive the selected products with a map of extra inputs, like: `%{"new_price" => "3.5"}` for example.
 

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -114,8 +114,8 @@
                         <%= if Map.has_key?(extra, :use_select) && extra.use_select do %>
                           <label><%= extra.title %></label>
                           <select data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" class="form-select w-100 kaffy-list-action-input">
-                            <%= for option <- extra.options do %>
-                              <option value="<%= Enum.at(option, 1) %>"><%= Enum.at(option, 0) %></option>
+                            <%= for [text, value] <- extra.options do %>
+                              <option value="<%= value %>"><%= text %></option>
                             <% end %>
                           </select>
                         <% else %>

--- a/lib/kaffy_web/templates/resource/index.html.eex
+++ b/lib/kaffy_web/templates/resource/index.html.eex
@@ -111,8 +111,17 @@
                   <div class="modal-body">
                     <%= for extra <- extra_inputs do %>
                       <div class="form-group">
-                        <label><%= extra.title %></label>
-                        <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= extra.default %>" class="form-control kaffy-list-action-input" />
+                        <%= if Map.has_key?(extra, :use_select) && extra.use_select do %>
+                          <label><%= extra.title %></label>
+                          <select data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" class="form-select w-100 kaffy-list-action-input">
+                            <%= for option <- extra.options do %>
+                              <option value="<%= Enum.at(option, 1) %>"><%= Enum.at(option, 0) %></option>
+                            <% end %>
+                          </select>
+                        <% else %>
+                          <label><%= extra.title %></label>
+                          <input type="text" data-title="<%= extra.title %>" name="kaffy-input[<%= extra.name %>]" value="<%= extra.default %>" class="form-control kaffy-list-action-input" />
+                        <% end %>
                       </div>
                     <% end %>
                   </div>


### PR DESCRIPTION
Allows users to have a `select` input instead of a text input in their list actions form. Can be accomplished by passing in `:use_select` as `true` in the input map and a list of `:options` formatted like `[[display, value], [display, value]]`.

![Screen Shot 2022-08-09 at 3 23 27 PM](https://user-images.githubusercontent.com/25255820/183744134-6d021693-aadd-4424-baea-7de044880444.png)
![Screen Shot 2022-08-09 at 3 23 46 PM](https://user-images.githubusercontent.com/25255820/183744203-29cd6077-e509-488e-babe-4c50593dd563.png)

